### PR TITLE
Removed parser functions from enny library

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,10 @@
-var Ul = require("ul");
-var Typpy = require("typpy");
-var Deffy = require("deffy");
-var IterateObject = require("iterate-object");
-var SetOrGet = require("set-or-get");
-var ObjectMap = require("map-o");
+var Ul = require("ul")
+  , Typpy = require("typpy")
+  , Deffy = require("deffy")
+  , IterateObject = require("iterate-object")
+  , SetOrGet = require("set-or-get")
+  , ObjectMap = require("map-o")
+  ;
 
 const TYPES = (function () {
 


### PR DESCRIPTION
Fixes #3. Moving the parser functions in engine-parser.
