### PR TITLE
Add flow method improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,8 @@ console.log(JSON.stringify(e, null, 4));
 //                 "B"
 //             ],
 //             "flow": [
-//                 [
-//                     [
-//                         "foo"
-//                     ],
-//                     [
-//                         ":foo",
-//                         1,
-//                         2,
-//                         3
-//                     ]
-//                 ]
+//                 [],
+//                 []
 //             ]
 //         }
 //     },
@@ -73,6 +64,31 @@ console.log(JSON.stringify(e, null, 4));
 //         "name": "B"
 //     }
 // }
+
+console.log(new Enny.FlowComponent({ error: "foo", args: ["bar", "baz"]}).toFlow());
+// => ["!foo", "bar", "baz"]
+
+console.log(new Enny.FlowComponent({ emit: "some-event" }).toFlow());
+// => [ 'flow', 'some-event' ]
+
+console.log(new Enny.FlowComponent({ emit: "some-event", to: "some-instance" }).toFlow());
+// => [ 'some-instance/flow', 'some-event' ]
+
+console.log(new Enny.FlowComponent({ link: "server-event", to: "some-instance" }).toFlow());
+// => [ 'flow', '@some-instance/server-event' ]
+
+console.log(new Enny.FlowComponent({ stream: "someStream", to: "some-instance" }).toFlow());
+// => some-instance/someStream
+
+console.log(new Enny.FlowElement([
+    { event: "listener-event" }
+  , { error: "error-handler" }
+  , { stream: "someStream", to: "some-instance" }
+]).toFlow());
+// =>
+// [ 'listener-event',
+//   '!error-handler',
+//   'some-instance/someStream' ]
 
 ```
 
@@ -89,6 +105,14 @@ Converts the internal composition into an object.
 
 #### Return
 - **Object** The modified composition.
+
+### `renameInstance(oldName, newName, cb)`
+Renames the specified instance. This will update the instance references in the entire app.
+
+#### Params
+- **String** `oldName`: The old instance name.
+- **String** `newName`: The new instance name.
+- **Function** `cb`: The callback function.
 
 ### `toJSON()`
 This function is called internally when `JSON.stringify`-ing the things.
@@ -129,7 +153,14 @@ Connect two instances.
 #### Return
 - **Instance** The current instance.
 
-### `addFlow(flElm, options, callback)`
+### `addFlow(flow, options)`
+Adds a set of FlowElements to the current instance.
+
+#### Params
+- **Array** `flow`: An array of human-readable objects, interpreted by `FlowElement`.
+- **Object** `options`: The object passed to `FlowElement`.
+
+### `addFlowElement(flElm, options, callback)`
 Adds flow configuration.
 
 #### Params

--- a/example/index.js
+++ b/example/index.js
@@ -27,17 +27,8 @@ console.log(JSON.stringify(e, null, 4));
 //                 "B"
 //             ],
 //             "flow": [
-//                 [
-//                     [
-//                         "foo"
-//                     ],
-//                     [
-//                         ":foo",
-//                         1,
-//                         2,
-//                         3
-//                     ]
-//                 ]
+//                 [],
+//                 []
 //             ]
 //         }
 //     },
@@ -50,14 +41,23 @@ console.log(new Enny.FlowComponent({ error: "foo", args: ["bar", "baz"]}).toFlow
 // => ["!foo", "bar", "baz"]
 
 console.log(new Enny.FlowComponent({ emit: "some-event" }).toFlow());
+// => [ 'flow', 'some-event' ]
+
 console.log(new Enny.FlowComponent({ emit: "some-event", to: "some-instance" }).toFlow());
+// => [ 'some-instance/flow', 'some-event' ]
+
 console.log(new Enny.FlowComponent({ link: "server-event", to: "some-instance" }).toFlow());
-// => ["!foo", "bar", "baz"]
+// => [ 'flow', '@some-instance/server-event' ]
 
 console.log(new Enny.FlowComponent({ stream: "someStream", to: "some-instance" }).toFlow());
+// => some-instance/someStream
 
 console.log(new Enny.FlowElement([
     { event: "listener-event" }
   , { error: "error-handler" }
   , { stream: "someStream", to: "some-instance" }
 ]).toFlow());
+// =>
+// [ 'listener-event',
+//   '!error-handler',
+//   'some-instance/someStream' ]

--- a/lib/index.js
+++ b/lib/index.js
@@ -288,7 +288,16 @@ Enny.Instance.prototype.connect = function (ins, options, callback) {
     return self;
 };
 
-Enny.Instance.prototype.addFlow = function (flow, options, callback) {
+/**
+ * addFlow
+ * Adds a set of FlowElements to the current instance.
+ *
+ * @name addFlow
+ * @function
+ * @param {Array} flow An array of human-readable objects, interpreted by `FlowElement`.
+ * @param {Object} options The object passed to `FlowElement`.
+ */
+Enny.Instance.prototype.addFlow = function (flow, options) {
     var self = this;
     flow.forEach(function (c) {
         self.addFlowElement(c, options);


### PR DESCRIPTION
- Renamed the old `addFlow` method into `addFlowElement`
- Added the `addFlow` method which receives as input an array of flow elements.
- Added the `renameInstance` which renames the instance itself and its references across instances. Fixed #8.

Enny is now used in [`engine-parser-gen`](https://github.com/jillix/engine-parser-gen)–which fixes #9. :sparkles: 
